### PR TITLE
specified hugo version in yaml files for github actions

### DIFF
--- a/content/posts/202310-blowfish-tutorial/index.md
+++ b/content/posts/202310-blowfish-tutorial/index.md
@@ -310,6 +310,9 @@ jobs:
     steps:
       - name: Hugo setup
         uses: peaceiris/actions-hugo@v2.6.0
+        with: 
+          hugo-version: 0.115.4
+          extended: true
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
 
@@ -351,6 +354,9 @@ jobs:
     steps:
       - name: Hugo setup
         uses: peaceiris/actions-hugo@v2.6.0
+        with: 
+          hugo-version: 0.115.4
+          extended: true
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
 


### PR DESCRIPTION
When deploying your blowfish site to firebase you can use Github Actions to build and deploy your site. If you don't specify the version of Hugo you want to use to build your site then the site won't render properly. Specifically, the HTML showing information such as post views/ date posted / author won't render.

Specifying the Hugo version to 0.115.4 extended solves this issue and the site renders properly.